### PR TITLE
add grype and syft to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM docker:20.10.9
 
 ARG BUILDX_VERSION=v0.6.3
+ARG GRYPE_VERSION=v0.33.1
+ARG SYFT_VERSION=v0.41.4
 
 RUN apk add \ 
     curl \
@@ -11,4 +13,6 @@ RUN apk add \
     -L \
     -o /usr/libexec/docker/cli-plugins/docker-buildx \
     https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-amd64 \
-  && chmod 755 /usr/libexec/docker/cli-plugins/docker-buildx 
+  && chmod 755 /usr/libexec/docker/cli-plugins/docker-buildx \
+  && curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION \
+  && curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin $SYFT_VERSION


### PR DESCRIPTION
These are tools I would like to start using for scanning docker images we build during CI (grype) and producing SBOMs for those images at release time (syft).

See https://github.com/brigadecore/brigade/issues/1864 and https://github.com/brigadecore/brigade/issues/1863