### PR TITLE
add ghr to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM docker:20.10.9
+FROM golang:1.17.8-bullseye as builder
+
+ARG GHR_VERSION=v0.14.0
+ARG CGO_ENABLED=0
+ARG GOPATH=/tmp/gotools
+
+RUN go get -v github.com/tcnksm/ghr@$GHR_VERSION \
+    && mv $GOPATH/bin/* /usr/local/bin/
+
+FROM docker:20.10.9 as final
 
 ARG BUILDX_VERSION=v0.6.3
 ARG GRYPE_VERSION=v0.33.1
 ARG SYFT_VERSION=v0.41.4
+
+COPY --from=builder /usr/local/bin/ghr /usr/local/bin/ghr
 
 RUN apk add \ 
     curl \


### PR DESCRIPTION
#7 added syft (a tool for generating SBOMs from a Docker image) to this set of tools.

This PR follows up on that, adding ghr (a tool we're comfortable with and have used elsewhere) so SBOMs can be published to a release on GH as soon as they're generated. i.e. Adding this tool here means our pipelines don't need to use two separate jobs to generate and publish (using different images that have different sets of tools). Were we to do that, we'd also have to add shared storage for passing the SBOM from one job to the next. We haven't needed shared storage up to this point and I don't want to add it if we don't need to.

This seems like the path of least resistance.